### PR TITLE
feat: add touch drag-and-drop support for mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,6 @@
 </div>
 
   <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js"></script>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/js/touch-support.js
+++ b/js/touch-support.js
@@ -1,0 +1,55 @@
+export function enableTouchDrag(ev) {
+  ev.preventDefault();
+
+  const draggingElem = ev.target.closest('.tier-item-wrapper');
+  if (!draggingElem) return;
+
+  /**
+   * スマートフォンでのドラッグ移動時の挙動を設定
+   *
+   * @param {Event} ev
+   */
+  const handleTouchMove = (ev) => {
+    const touch = ev.touches[0];
+
+    // 追従用classを追加
+    draggingElem.classList.add('touch-dragging');
+
+    // ドラッグ中の要素を画面上で移動させる
+    draggingElem.style.position = 'fixed';
+    draggingElem.style.left = `${
+      touch.clientX - draggingElem.offsetWidth / 2
+    }px`;
+    draggingElem.style.top = `${
+      touch.clientY - draggingElem.offsetHeight / 2
+    }px`;
+  };
+
+  /**
+   * スマートフォンでのドラッグ終了時の挙動を設定
+   *
+   * @param {Event} ev
+   */
+  const handleTouchEnd = (ev) => {
+    const touch = ev.changedTouches[0];
+    // ドロップ先の要素を取得
+    const dropArea = document
+      .elementFromPoint(touch.clientX, touch.clientY)
+      ?.closest('.tier');
+    const dropTarget = dropArea?.querySelector('.tier-row');
+    if (dropTarget) {
+      dropTarget.appendChild(draggingElem);
+    }
+
+    // ドラッグ中の要素を元の位置に戻す
+    draggingElem.classList.remove('touch-dragging');
+    draggingElem.style.left = '';
+    draggingElem.style.top = '';
+    draggingElem.style.position = '';
+    document.removeEventListener('touchmove', handleTouchMove);
+    document.removeEventListener('touchend', handleTouchEnd);
+  };
+
+  document.addEventListener('touchmove', handleTouchMove, { passive: false });
+  document.addEventListener('touchend', handleTouchEnd);
+}

--- a/script.js
+++ b/script.js
@@ -1,6 +1,9 @@
+import { enableTouchDrag } from "./js/touch-support.js";
+
 function allowDrop(ev) {
   ev.preventDefault();
 }
+window.allowDrop = allowDrop;
 
 function drag(ev) {
   ev.dataTransfer.setData("text/plain", ev.target.id);
@@ -24,6 +27,7 @@ function drop(ev) {
     row.appendChild(dragged);
   }
 }
+window.drop = drop;
 
 let itemCount = 0;
 const poolRow = document.getElementById("poolRow");
@@ -41,6 +45,7 @@ function createImageElement(src, labelText = "") {
   img.setAttribute("draggable", "true");
   img.id = "item-" + itemCount++;
   img.addEventListener("dragstart", drag);
+  img.addEventListener("touchstart", enableTouchDrag, { passive: false });
 
   // 右クリック処理
   img.addEventListener("contextmenu", (e) => {

--- a/style.css
+++ b/style.css
@@ -182,3 +182,10 @@ body {
   max-height: 120px;
   flex: 0 0 120px;
 }
+
+.touch-dragging {
+  pointer-events: none;
+  opacity: 0.6;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transition: opacity 0.2s, ease;
+}


### PR DESCRIPTION
- File that describes the process of reproducing the drag-and-drop motion on a smartphone (`. /js/touch-support.js`) describing the process of reproducing the drag-and-drop motion on a smartphone.
- Called the above file in script.js and added a description that fires on the `touchstart` event.
- Added style definitions such as transparent display for drag & drop.

[日本語]
- スマートフォンでドラッグ&ドロップの動きを再現する処理を記述したファイル (`./js/touch-support.js`)を作成しました。
- `script.js`で上記ファイルを呼び出し、 `touchstart` イベントで発火する記述を追加しました。
- スマートフォンでのドラッグ&ドロップ時の透過表示など、style定義を追加しました。